### PR TITLE
add summary field to douban collection object

### DIFF
--- a/src/main/java/com/dongxuexidu/douban4j/model/collection/DoubanCollectionObj.java
+++ b/src/main/java/com/dongxuexidu/douban4j/model/collection/DoubanCollectionObj.java
@@ -58,6 +58,25 @@ public class DoubanCollectionObj implements IDoubanObject{
   @Key("db:attribute")
   private List<DoubanAttributeObj> att;
 
+
+  @Key("summary")
+  private String summary;
+
+  /**
+  * @return user summary on current collection
+  * */
+  public String getSummary() {
+    return summary;
+  }
+
+  /**
+  * @param summary to set
+  * */
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+
+
   /**
    * @return the updateTime
    */

--- a/src/test/java/com/dongxuexidu/douban4j/service/DoubanCollectionServiceTest.java
+++ b/src/test/java/com/dongxuexidu/douban4j/service/DoubanCollectionServiceTest.java
@@ -55,9 +55,9 @@ public class DoubanCollectionServiceTest extends TestCase {
   public void testGetUsersCollection_8args() throws Exception {
     System.out.println("getUsersCollection");
     String userId = "xxx";
-    CollectionCategory category = CollectionCategory.Movie;
+    CollectionCategory category = CollectionCategory.Music;
     String tag = "";
-    CollectionStatus status = CollectionStatus.MovieEd;
+    CollectionStatus status = CollectionStatus.MusicEd;
     Integer startIndex = 0;
     Integer maxResult = 2;
     Date startDate = null;
@@ -67,7 +67,8 @@ public class DoubanCollectionServiceTest extends TestCase {
     for (DoubanCollectionObj col : result.getCollections()) {
       System.out.println("col title : " + col.getTitle());
       System.out.println("col id : " + col.getId());
-      System.out.println("col subject title : " + col.getSubject().getTitle());
+      System.out.println("col user summary : " + col.getSummary());
+//      System.out.println("col subject title : " + col.getSubject().getTitle());
     }
     assertTrue(result.getCollections().size() > 0);
   }


### PR DESCRIPTION
对douban collection object增加了summary这个字段，以便获取douban接口返回的summary信息。

ps. 这个豆瓣collection接口现在好像就剩下music的能用了，其它都迁移到v2.0了。对于音乐collection来说这个字段是用户的短评信息。
