### PR TITLE
修改了DoubanSubjectObj某些字段的@Key使得SDK能够获取attribute，tag字段数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/.idea/
+*.iml

--- a/src/main/java/com/dongxuexidu/douban4j/model/subject/DoubanSubjectObj.java
+++ b/src/main/java/com/dongxuexidu/douban4j/model/subject/DoubanSubjectObj.java
@@ -39,10 +39,10 @@ public class DoubanSubjectObj implements IDoubanObject {
   @Key("link")
   private List<DoubanLinkObj> links = new ArrayList<DoubanLinkObj>();
   
-  @Key("db:tag")
+  @Key("db2:tag")
   private List<DoubanTagObj> tags = new ArrayList<DoubanTagObj>();
   
-  @Key("db:attribute")
+  @Key("db2:attribute")
   private List<DoubanAttributeObj> attributes = new ArrayList<DoubanAttributeObj>();
   
   @Key


### PR DESCRIPTION
com.dongxuexidu.douban4j.service.DoubanBookMovieMusicService#getMusicInfoById
这个方法无法获取db:attribute或者db:tag的字段。
其它类似的方法应该也有类似问题。

样例请求：
https://api.douban.com/music/subject/4753298
原因是在于sdk中请求的是https的douban API，而https的API对应的alias是db2而不是db。
因此google的api在反序列化的时候没有把attribute和tag字段转换出来。

将java bean里相应字段的@Key改为db2就可以了。

如下方法测试通过：
com.dongxuexidu.douban4j.service.DoubanBookMovieMusicServiceTest#testGetMusicInfoById

ps. 另外不小心修改了.gitignore也提交了，只是忽略掉idea IDE相关的文件，干脆也一并PR了。:)
